### PR TITLE
feat: add create comment by custom account support

### DIFF
--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -51,7 +51,8 @@ provide<Ref<User | undefined>>("currentUser", currentUser);
 const handleFetchLoginedUser = async () => {
   try {
     const { data } = await apiClient.user.getCurrentUserDetail();
-    currentUser.value = data;
+    currentUser.value =
+      data.metadata.name === "anonymousUser" ? undefined : data;
   } catch (error) {
     console.error("Fetch logined user failed", error);
   }

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
-import { VModal, VButton } from "@halo-dev/components";
+import { VModal, VButton, Toast } from "@halo-dev/components";
 import { ref, watch } from "vue";
 import { v4 as uuid } from "uuid";
 import qs from "qs";
+import axios from "axios";
 
 const props = withDefaults(
   defineProps<{
@@ -43,19 +44,21 @@ const handleLogin = async () => {
   try {
     loading.value = true;
 
-    await fetch(`${import.meta.env.VITE_API_URL}/login`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      credentials: "include",
-      redirect: "manual",
-      body: qs.stringify(formState.value),
-    });
+    await axios.post(
+      `${import.meta.env.VITE_API_URL}/login`,
+      qs.stringify(formState.value),
+      {
+        withCredentials: true,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      }
+    );
 
     window.location.reload();
   } catch (e) {
     console.error("Failed to login", e);
+    Toast.error("登录失败，用户名或密码错误");
   } finally {
     loading.value = false;
   }

--- a/src/components/ReplyItem.vue
+++ b/src/components/ReplyItem.vue
@@ -79,6 +79,7 @@ const isHoveredReply = computed(() => {
               {{ timeAgo }}
             </a>
             <VTag
+              v-if="false"
               rounded
               class="dark:!border-slate-600 dark:!bg-slate-700 dark:!text-slate-50"
             >

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import Comment from "@/components/Comment.vue";
-import "@halo-dev/components/dist/style.css";
 import "@/styles/tailwind.css";
 import "@/styles/dark.css";
 import "@/styles/index.css";
+import "@halo-dev/components/dist/style.css";
 import type { App, Plugin } from "vue";
 
 const plugin: Plugin = {


### PR DESCRIPTION
支持通过自行填写账号信息来评论。

目前的逻辑是：

1. 如果有登录，则不显示 `昵称` `电子邮箱` `网站` 的输入框。
2. 暂时没有判断是否开启了 `仅允许注册用户评论`。 https://github.com/halo-dev/halo/issues/3117

<img width="909" alt="image" src="https://user-images.githubusercontent.com/21301288/211269817-81a87a64-79f0-4098-800c-80f8a7413a62.png">

/kind improvement

```release-note
支持通过自行填写账号信息来评论
```
