### PR TITLE
perf: use alert api instead of toast component

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { VButton, VAvatar, Toast, Dialog } from "@halo-dev/components";
+import { VButton, VAvatar } from "@halo-dev/components";
 import LoginModal from "./LoginModal.vue";
 import data from "@emoji-mart/data";
 import i18n from "@emoji-mart/data/i18n/zh.json";
@@ -90,11 +90,11 @@ const handleCreateComment = async () => {
 
     if (!currentUser?.value) {
       if (!customAccount.value.displayName) {
-        Toast.warning("请填写昵称");
+        alert("请填写昵称");
         return;
       }
       if (!customAccount.value.email) {
-        Toast.warning("请填写电子邮件");
+        alert("请填写电子邮件");
         return;
       }
       commentRequest.owner = {
@@ -108,8 +108,6 @@ const handleCreateComment = async () => {
       commentRequest,
     });
     raw.value = "";
-
-    Toast.success("评论成功");
 
     emit("created");
   } catch (error) {
@@ -138,11 +136,11 @@ const handleCreateReply = async () => {
 
     if (!currentUser?.value) {
       if (!customAccount.value.displayName) {
-        Toast.warning("请填写昵称");
+        alert("请填写昵称");
         return;
       }
       if (!customAccount.value.email) {
-        Toast.warning("请填写电子邮件");
+        alert("请填写电子邮件");
         return;
       }
       replyRequest.owner = {
@@ -158,8 +156,6 @@ const handleCreateReply = async () => {
     });
     raw.value = "";
 
-    Toast.success("回复成功");
-
     emit("created");
   } catch (error) {
     console.error("Failed to create comment reply", error);
@@ -168,21 +164,18 @@ const handleCreateReply = async () => {
   }
 };
 
-const handleLogout = () => {
-  Dialog.warning({
-    title: "确定要退出登录吗？",
-    onConfirm: async () => {
-      try {
-        await axios.post(`${import.meta.env.VITE_API_URL}/logout`, undefined, {
-          withCredentials: true,
-        });
+const handleLogout = async () => {
+  if (window.confirm("确定要退出登录吗？")) {
+    try {
+      await axios.post(`${import.meta.env.VITE_API_URL}/logout`, undefined, {
+        withCredentials: true,
+      });
 
-        window.location.reload();
-      } catch (error) {
-        console.error("Failed to logout", error);
-      }
-    },
-  });
+      window.location.reload();
+    } catch (error) {
+      console.error("Failed to logout", error);
+    }
+  }
 };
 
 // Emoji picker

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { VModal, VButton, Toast } from "@halo-dev/components";
+import { VModal, VButton } from "@halo-dev/components";
 import { ref, watch } from "vue";
 import { v4 as uuid } from "uuid";
 import qs from "qs";
@@ -58,7 +58,7 @@ const handleLogin = async () => {
     window.location.reload();
   } catch (e) {
     console.error("Failed to login", e);
-    Toast.error("登录失败，用户名或密码错误");
+    alert("登录失败，用户名或密码错误");
   } finally {
     loading.value = false;
   }

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -2,7 +2,6 @@ import {
   ApiConsoleHaloRunV1alpha1UserApi,
   ApiHaloRunV1alpha1CommentApi,
 } from "@halo-dev/api-client";
-import { Toast } from "@halo-dev/components";
 import axios, { AxiosError } from "axios";
 
 const apiUrl = import.meta.env.VITE_API_URL;
@@ -25,21 +24,21 @@ axiosInstance.interceptors.response.use(
   },
   async (error: AxiosError<ProblemDetail>) => {
     if (/Network Error/.test(error.message)) {
-      Toast.error("网络错误，请检查网络连接");
+      alert("网络错误，请检查网络连接");
       return Promise.reject(error);
     }
 
     const errorResponse = error.response;
 
     if (!errorResponse) {
-      Toast.error("网络错误，请检查网络连接");
+      alert("网络错误，请检查网络连接");
       return Promise.reject(error);
     }
 
     const { title, detail } = errorResponse.data;
 
     if (title && detail) {
-      Toast.error([title, detail].join(": "));
+      alert([title, detail].join(": "));
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
使用 alert 代替 `@halo-dev/components` 中的 Toast 组件，因为目前在 [plugin-comment-widget](https://github.com/halo-sigs/plugin-comment-widget) 中无法正常使用。

详细原因请看：https://github.com/halo-dev/halo/issues/3141

/kind improvement

```release-note
None
```