### PR TITLE
perf: improve comments by anonymous user

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -12,5 +12,11 @@ export default defineConfig({
   },
   server: {
     port: 4000,
+    proxy: {
+      "/actuator": {
+        target: "http://localhost:8090",
+        changeOrigin: true,
+      },
+    },
   },
 });

--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -11,6 +11,8 @@ import Form from "./Form.vue";
 import { computed, onMounted, provide, ref, type Ref } from "vue";
 import type { CommentVoList, User } from "@halo-dev/api-client";
 import { apiClient } from "../utils/api-client";
+import axios from "axios";
+import type { GlobalInfo } from "../types";
 
 const props = withDefaults(
   defineProps<{
@@ -106,6 +108,24 @@ const getColorScheme = computed(() => {
   }
   return props.colorScheme;
 });
+
+// fetch value of allowAnonymousComments
+
+const allowAnonymousComments = ref<boolean | undefined>(false);
+
+provide<Ref<Boolean | undefined>>(
+  "allowAnonymousComments",
+  allowAnonymousComments
+);
+
+const handleFetchValueOfAllowAnonymousComments = async () => {
+  const { data } = await axios.get<GlobalInfo>(`/actuator/globalinfo`, {
+    withCredentials: true,
+  });
+  allowAnonymousComments.value = data.allowAnonymousComments;
+};
+
+onMounted(handleFetchValueOfAllowAnonymousComments);
 </script>
 <template>
   <div class="halo-comment-widget" :class="getColorScheme">

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,8 @@
+export interface GlobalInfo {
+  externalUrl: string;
+  timeZone: string;
+  locale: string;
+  allowComments: boolean;
+  allowAnonymousComments: boolean;
+  allowRegistration: boolean;
+}


### PR DESCRIPTION
优化匿名访客评论的判断方式，依赖于 https://github.com/halo-dev/halo/pull/3182

现在的逻辑修改为：

1. 如果在设置中勾选了 `仅允许注册用户评论` 选项，那么不会显示自定义评论者的表单。
2. 如果取消勾选 `仅允许注册用户评论` 选项，会同时支持自定义评论者信息和登录。

<img width="1118" alt="image" src="https://user-images.githubusercontent.com/21301288/215439779-b014edbe-e4ed-4bb5-8e17-6756900b435d.png">
<img width="1117" alt="image" src="https://user-images.githubusercontent.com/21301288/215439952-2e0db7da-2efe-4a50-b07c-f7603602199c.png">

/kind improvement

```release-note
优化匿名访客评论的判断方式
```